### PR TITLE
Add docker scratch image

### DIFF
--- a/docker/scratch.Dockerfile
+++ b/docker/scratch.Dockerfile
@@ -24,3 +24,6 @@ RUN adduser \
 FROM scratch
 WORKDIR /data/
 
+# Copy files from builder
+COPY --from=builder /etc/passwd /etc/passwd
+COPY --from=builder /etc/group /etc/group

--- a/docker/scratch.Dockerfile
+++ b/docker/scratch.Dockerfile
@@ -28,3 +28,8 @@ WORKDIR /data/
 COPY --from=builder /etc/passwd /etc/passwd
 COPY --from=builder /etc/group /etc/group
 COPY --chown=versatiles:versatiles --from=builder /usr/local/cargo/bin/versatiles /usr/local/cargo/bin/versatiles
+
+USER versatiles
+EXPOSE 8080
+
+CMD ["/usr/local/cargo/bin/versatiles", "serve", "-i", "0.0.0.0", "-p", "8080", "-s", "/data/static", "/data/tiles/osm.versatiles"]

--- a/docker/scratch.Dockerfile
+++ b/docker/scratch.Dockerfile
@@ -19,3 +19,8 @@ RUN adduser \
     --no-create-home \ 
     --uid "${UID}" \ 
     "${USER}"
+
+# Setup Final Docker Image
+FROM scratch
+WORKDIR /data/
+

--- a/docker/scratch.Dockerfile
+++ b/docker/scratch.Dockerfile
@@ -1,0 +1,9 @@
+# Compile Versatiles Binary inside Builder
+FROM rust:alpine as builder
+
+COPY ../ /usr/src/versatiles
+WORKDIR /usr/src/versatiles
+
+RUN apk add sqlite-dev curl gzip musl-dev git
+RUN rustup default stable
+RUN cargo install versatiles 

--- a/docker/scratch.Dockerfile
+++ b/docker/scratch.Dockerfile
@@ -7,3 +7,15 @@ WORKDIR /usr/src/versatiles
 RUN apk add sqlite-dev curl gzip musl-dev git
 RUN rustup default stable
 RUN cargo install versatiles 
+
+# Create appuser
+ENV USER=versatiles
+ENV UID=1000
+RUN adduser \ 
+    --disabled-password \ 
+    --gecos "" \ 
+    --home "/nonexistent" \ 
+    --shell "/sbin/nologin" \ 
+    --no-create-home \ 
+    --uid "${UID}" \ 
+    "${USER}"

--- a/docker/scratch.Dockerfile
+++ b/docker/scratch.Dockerfile
@@ -8,7 +8,7 @@ RUN apk add sqlite-dev curl gzip musl-dev git
 RUN rustup default stable
 RUN cargo install versatiles 
 
-# Create appuser
+# Create User
 ENV USER=versatiles
 ENV UID=1000
 RUN adduser \ 

--- a/docker/scratch.Dockerfile
+++ b/docker/scratch.Dockerfile
@@ -27,3 +27,4 @@ WORKDIR /data/
 # Copy files from builder
 COPY --from=builder /etc/passwd /etc/passwd
 COPY --from=builder /etc/group /etc/group
+COPY --chown=versatiles:versatiles --from=builder /usr/local/cargo/bin/versatiles /usr/local/cargo/bin/versatiles


### PR DESCRIPTION
Hey,

This is a scratched Dockerfile and create a 8MiB small Image. 
The Image includes only the Binary and a internal user for hardening of the system. 

```
docker build -t versatiles -f ./docker/scratch.Dockerfile .
```

I hope that helps for faster Docker Deployments :) 
And thanks for the very good and small osm tile server :D
