### PR TITLE
Add CORS headers on 400 and 404 responses

### DIFF
--- a/versatiles/src/tools/server/tile_server.rs
+++ b/versatiles/src/tools/server/tile_server.rs
@@ -239,6 +239,7 @@ impl TileServer {
 fn error_400() -> Response<Body> {
 	Response::builder()
 		.status(400)
+		.header(ACCESS_CONTROL_ALLOW_ORIGIN, "*")
 		.body(Body::from("Bad Request"))
 		.expect("should have build a body")
 }
@@ -246,6 +247,7 @@ fn error_400() -> Response<Body> {
 fn error_404() -> Response<Body> {
 	Response::builder()
 		.status(404)
+		.header(ACCESS_CONTROL_ALLOW_ORIGIN, "*")
 		.body(Body::from("Not Found"))
 		.expect("should have build a body")
 }


### PR DESCRIPTION
The CORS headers should be handled consistently, on "successful" and "unsuccessful" responses, because a response without CORS headers will be denied by the browser without providing any additional info.

This fixes #138.