### PR TITLE
docs: Added nixpkgs-badge and Updated Table of Contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ VersaTiles is a Rust-based tool for processing and serving tile data efficiently
   - [MacOS](#macos)
   - [NixOS](#nixos)
   - [Docker](#docker)
+  - [npm (Node.js)](#npm-nodejs)
   - [Building with Cargo](#building-with-cargo)
   - [Building from Source](#building-from-source)
 - [Quick Start](#quick-start)
@@ -32,11 +33,11 @@ VersaTiles is a Rust-based tool for processing and serving tile data efficiently
   - [Development Workflow](#development-workflow)
   - [Pre-commit Hooks (Recommended)](#pre-commit-hooks-recommended)
   - [Node.js Bindings Development](#nodejs-bindings-development)
-  - [Release Process](#release-process)
   - [Contributing](#contributing)
 - [Repository Structure](#repository-structure)
 - [Using as a Library](#using-as-a-library)
 - [Additional Information](#additional-information)
+- [For Maintainers](#for-maintainers)
 - [Contributing](#contributing)
 - [License](#license)
 
@@ -65,10 +66,11 @@ brew install versatiles
 
 VersaTiles is available via `nixpkgs` (starting from version 24.05):
 
-[![nixpkgs stable 24.05](https://repology.org/badge/version-for-repo/nix_stable_24_05/versatiles.svg?header=nixpkgs%20stable%2024.05)](https://repology.org/project/versatiles/versions)
-[![nixpkgs stable 24.11](https://repology.org/badge/version-for-repo/nix_stable_24_11/versatiles.svg?header=nixpkgs%20stable%2024.11)](https://repology.org/project/versatiles/versions)
-[![nixpkgs stable 25.05](https://repology.org/badge/version-for-repo/nix_stable_25_05/versatiles.svg?header=nixpkgs%20stable%2025.05)](https://repology.org/project/versatiles/versions)
 [![nixpkgs unstable](https://repology.org/badge/version-for-repo/nix_unstable/versatiles.svg?header=nixpkgs%20unstable)](https://repology.org/project/versatiles/versions)
+[![nixpkgs stable 25.11](https://repology.org/badge/version-for-repo/nix_stable_25_11/versatiles.svg?header=nixpkgs%20stable%2025.11)](https://repology.org/project/versatiles/versions)
+[![nixpkgs stable 25.05](https://repology.org/badge/version-for-repo/nix_stable_25_05/versatiles.svg?header=nixpkgs%20stable%2025.05)](https://repology.org/project/versatiles/versions)
+[![nixpkgs stable 24.11](https://repology.org/badge/version-for-repo/nix_stable_24_11/versatiles.svg?header=nixpkgs%20stable%2024.11)](https://repology.org/project/versatiles/versions)
+[![nixpkgs stable 24.05](https://repology.org/badge/version-for-repo/nix_stable_24_05/versatiles.svg?header=nixpkgs%20stable%2024.05)](https://repology.org/project/versatiles/versions)
 
 Add this snippet to `configuration.nix`:
 


### PR DESCRIPTION
The current stable nixpkgs badge was missing. I changed the order to have the current versions at the start of the list.

My markdown linter showed an entry in the Table of Contents that was broken. I removed it and added two new chapters to the list.