### PR TITLE
Potential fix for code scanning alert no. 14: Cleartext logging of sensitive information

### DIFF
--- a/versatiles_core/src/io/data_reader_http.rs
+++ b/versatiles_core/src/io/data_reader_http.rs
@@ -42,13 +42,22 @@ use tokio::time::sleep;
 use versatiles_derive::context;
 
 /// A struct that provides reading capabilities from an HTTP(S) endpoint.
-#[derive(Debug)]
 pub struct DataReaderHttp {
 	client: Client,
 	name: String,
 	url: Url,
 	username: Option<String>,
 	password: Option<String>,
+}
+
+impl std::fmt::Debug for DataReaderHttp {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("DataReaderHttp")
+			.field("client", &"Client { .. }")
+			.field("name", &self.name)
+			.field("url", &self.url)
+			.finish()
+	}
 }
 
 impl DataReaderHttp {


### PR DESCRIPTION
Potential fix for [https://github.com/versatiles-org/versatiles-rs/security/code-scanning/14](https://github.com/versatiles-org/versatiles-rs/security/code-scanning/14)

In general, to fix cleartext logging of sensitive information, you should ensure that sensitive values are never included in data that might be logged. For Rust structs, the main mechanism is to avoid `Debug` auto-derivation on types that contain secrets, or to implement `Debug` manually so that sensitive fields are redacted or omitted. Alternatively, you can remove sensitive fields entirely or store them in specialized secret types that have safe `Debug` implementations.

For this specific code, the simplest and most targeted fix without changing functionality is to stop auto-deriving `Debug` for `DataReaderHttp` and instead provide a manual `impl std::fmt::Debug for DataReaderHttp` that logs only non-sensitive information. Here, `password` is clearly sensitive, and `username` may also be considered sensitive; to be conservative, we should avoid including either in `Debug`. We can keep logging `name` and `url` (or even just `name`), which should be enough for diagnostics. The implementation will go in the same file, just below the struct definition, and will not require any new imports because `std::fmt` is in the prelude.

Concretely:
- Replace `#[derive(Debug)]` on `DataReaderHttp` with a plain `pub struct DataReaderHttp { ... }` (no `derive(Debug)`).
- Add a manual `impl std::fmt::Debug for DataReaderHttp` that only formats `client` (optionally as a placeholder), `name`, and `url`, and deliberately omits `username` and `password`. For example, print `client: Client { .. }` and `auth: REDACTED` or omit auth entirely.
- No changes to the password-handling logic itself are required; we just ensure it cannot leak via `Debug` output.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
