### PR TITLE
fix: VectorTileFeature::to_blob emits no geometry field when empty

### DIFF
--- a/versatiles_geometry/src/vector_tile/feature.rs
+++ b/versatiles_geometry/src/vector_tile/feature.rs
@@ -219,14 +219,12 @@ impl VectorTileFeature {
 			.write_varint(self.geom_type.as_u64())
 			.context("Failed to write geometry type")?;
 
-		if !self.geom_data.is_empty() {
-			writer
-				.write_pbf_key(4, 2)
-				.context("Failed to write PBF key for geometry data")?;
-			writer
-				.write_pbf_blob(&self.geom_data)
-				.context("Failed to write geometry data")?;
-		}
+		writer
+			.write_pbf_key(4, 2)
+			.context("Failed to write PBF key for geometry data")?;
+		writer
+			.write_pbf_blob(&self.geom_data)
+			.context("Failed to write geometry data")?;
 
 		Ok(writer.into_blob())
 	}


### PR DESCRIPTION
Another compatibility issue with Maplibre GL JS / Native I've noticed while playing with [landcover-vectors](https://github.com/versatiles-org/landcover-vectors) tileset: some of the features there have empty geometry fields. This makes not a lot of sense but valid in terms of specs and readers.

However when such feature is passed through `VectorTileFeature::to_blob`, the geometry field is omitted when the geometry field is empty:

https://github.com/versatiles-org/versatiles-rs/blob/8b9dae6ad6082a70f1552d794c26e2c95bfcc596/versatiles_geometry/src/vector_tile/feature.rs#L94-L101

Which violates MVT spec in this [§4.2](https://github.com/mapbox/vector-tile-spec/blob/5330dfc6ba2d5f8c8278c2c4f56fff2c7dee1dbd/2.1/README.md?plain=1#L59):
> A feature MUST contain a `geometry` field.


And causes mvt readers to throw runtime errors like `unknown command N`, where N is an arbitrary number it finds at offset -1.

The issue can be reproduced with forcing versatiles to re-encode tile, for example the following vpl with the datasets from [download.versatiles.org](https://download.versatiles.org/):

```
from_merged_vector [
   from_container filename="osm.versatiles",
   from_container filename="landcover-vectors.versatiles"
]
```

And some style with layers referencing `landcover-vectors` source-layer, Maplibre GL JS will throw errors at the tiles with empty geometry fields with messages `unknown command N`.