### PR TITLE
feat: make max tile byte size configurable via max_tile_bytes VPL arg

### DIFF
--- a/versatiles_pipeline/README.md
+++ b/versatiles_pipeline/README.md
@@ -177,6 +177,7 @@ Reads a CSV file with longitude/latitude columns and emits MVT point tiles.
 - *`point_reduction`: PointReductionStrategy (optional)* - Point reduction strategy: `none` / `drop_rate` / `min_distance` (default `min_distance`).
 - *`point_reduction_value`: f32 (optional)* - Numeric value whose meaning depends on `point_reduction`: - `min_distance` (default): minimum distance between kept points, in tile-pixels at the current zoom. Defaults to 16. - `drop_rate`: per-zoom keep-fraction in `[0, 1]`. Defaults to 0.5. - `none`: ignored.
 - *`compression`: TileCompression (optional)* - Tile-compression applied before the tiles leave this operation: `gzip` (default), `brotli`, `zstd`, or `none`.
+- *`max_tile_bytes`: u32 (optional)* - Maximum encoded tile size in bytes before a tile is considered broken and dropped (streaming path) / errors out (single-tile path). Defaults to 1048576 (1 MiB). `0` disables the hard cap entirely — tiles are emitted at any size (only the 200 KB soft-cap warning remains). Raise this when a legitimate low-zoom tile exceeds the default (e.g. `max_tile_bytes=2097152` for 2 MiB).
 
 ---
 
@@ -248,6 +249,7 @@ Reads a GeoJSON or Shapefile and emits MVT vector tiles.
 - *`point_reduction`: PointReductionStrategy (optional)* - Point reduction strategy: `none` / `drop_rate` / `min_distance` (default `min_distance`).
 - *`point_reduction_value`: f32 (optional)* - Numeric value whose meaning depends on `point_reduction`: - `min_distance` (default): minimum distance between kept points, in tile-pixels at the current zoom. Defaults to 16. - `drop_rate`: per-zoom keep-fraction in `[0, 1]`. Defaults to 0.5. - `none`: ignored.
 - *`compression`: TileCompression (optional)* - Tile-compression applied before the tiles leave this operation: `gzip` (default), `brotli`, `zstd`, or `none`.
+- *`max_tile_bytes`: u32 (optional)* - Maximum encoded tile size in bytes before a tile is considered broken and dropped (streaming path) / errors out (single-tile path). Defaults to 1048576 (1 MiB). `0` disables the hard cap entirely — tiles are emitted at any size (only the 200 KB soft-cap warning remains). Raise this when a legitimate low-zoom tile exceeds the default (e.g. `max_tile_bytes=2097152` for 2 MiB).
 - *`ignore_id`: bool (optional)* - If `true`, drop the GeoJSON / Shapefile `id` field from every feature before encoding. Useful for sources where the id is a string (e.g. USGS earthquakes — those would be silently dropped at MVT encode anyway, since MVT requires `uint64` ids), or when the id is just noise. Defaults to `false` — keep the id when it's a non-negative integer.
 
 ---

--- a/versatiles_pipeline/src/helpers/feature_tile_source.rs
+++ b/versatiles_pipeline/src/helpers/feature_tile_source.rs
@@ -16,7 +16,7 @@
 
 use crate::helpers::{
 	tile_error_monitor::{TileErrorMonitor, TileErrorStage},
-	tile_size_monitor::{TileBreakdown, TileSizeMonitor},
+	tile_size_monitor::{HARD_CAP_BYTES, TileBreakdown, TileSizeMonitor},
 };
 use anyhow::Result;
 use async_trait::async_trait;
@@ -68,6 +68,12 @@ impl FeatureTileSource {
 	/// `label` identifies the operation in monitor log lines (e.g.
 	/// `"from_geo"`); `source_description` and `source_short` go into the
 	/// `SourceType` used by tooling that introspects the pipeline.
+	///
+	/// `max_tile_bytes` sets the hard cap on encoded tile size, in bytes:
+	/// `None` keeps the default [`HARD_CAP_BYTES`] (1 MiB), `Some(0)` disables
+	/// the hard cap entirely, and `Some(n)` caps encoded tiles at `n` bytes.
+	/// Tiles above the cap are skipped by the streaming path and error out on
+	/// the single-tile path; the soft-cap (200 KB) warning is unaffected.
 	pub fn new(
 		import: FeatureImport,
 		layer_name: &str,
@@ -75,6 +81,7 @@ impl FeatureTileSource {
 		label: &'static str,
 		source_description: &'static str,
 		source_short: &'static str,
+		max_tile_bytes: Option<u32>,
 	) -> Result<Self> {
 		// Tile pyramid covers the data bbox over [min_zoom, max_zoom];
 		// for empty input, an empty pyramid.
@@ -97,11 +104,22 @@ impl FeatureTileSource {
 			metadata,
 			tilejson,
 			compression,
-			size_monitor: TileSizeMonitor::new(label),
+			size_monitor: TileSizeMonitor::new(label, resolve_hard_cap(max_tile_bytes)),
 			error_monitor: TileErrorMonitor::new(label),
 			source_description,
 			source_short,
 		})
+	}
+}
+
+/// Map a VPL `max_tile_bytes` argument to the [`TileSizeMonitor`]'s hard cap:
+/// absent → the default [`HARD_CAP_BYTES`] (1 MiB); `0` → `None`, i.e. the
+/// hard cap is disabled entirely; `n > 0` → cap encoded tiles at `n` bytes.
+fn resolve_hard_cap(max_tile_bytes: Option<u32>) -> Option<usize> {
+	match max_tile_bytes {
+		None => Some(HARD_CAP_BYTES),
+		Some(0) => None,
+		Some(n) => Some(n as usize),
 	}
 }
 
@@ -297,6 +315,10 @@ mod tests {
 	}
 
 	fn build_source(max_zoom: u8) -> FeatureTileSource {
+		build_source_with_cap(max_zoom, None)
+	}
+
+	fn build_source_with_cap(max_zoom: u8, max_tile_bytes: Option<u32>) -> FeatureTileSource {
 		let features: Vec<GeoFeature> = vec![
 			point_feature(1, "origin", 0.0, 0.0),
 			point_feature(2, "east", 90.0, 30.0),
@@ -316,6 +338,7 @@ mod tests {
 			"test_label",
 			"test source",
 			"test",
+			max_tile_bytes,
 		)
 		.unwrap()
 	}
@@ -380,6 +403,46 @@ mod tests {
 		let coord = TileCoord::new(2, 0, 3)?;
 		let tile = source.tile(&coord).await?;
 		assert!(tile.is_none(), "tile outside data must be None");
+		Ok(())
+	}
+
+	#[tokio::test]
+	async fn tile_errors_when_above_configured_hard_cap() -> Result<()> {
+		// A 1-byte cap makes every rendered tile over-cap: the single-tile API
+		// must propagate the error rather than drop the tile.
+		let source = build_source_with_cap(2, Some(1));
+		let coord = TileCoord::new(0, 0, 0)?;
+		let err = source.tile(&coord).await.unwrap_err();
+		assert!(format!("{err:#}").contains("hard cap"), "{err:#}");
+		Ok(())
+	}
+
+	#[tokio::test]
+	async fn tile_passes_when_hard_cap_disabled() -> Result<()> {
+		// `max_tile_bytes=0` disables the hard cap: the same tile that errored
+		// under a 1-byte cap is emitted normally.
+		let source = build_source_with_cap(2, Some(0));
+		let coord = TileCoord::new(0, 0, 0)?;
+		let tile = source.tile(&coord).await?;
+		assert!(tile.is_some(), "disabled hard cap must emit the tile");
+		Ok(())
+	}
+
+	#[tokio::test]
+	async fn tile_stream_obeys_configured_hard_cap() -> Result<()> {
+		// The streaming path skips over-cap tiles (returning None), so a 1-byte
+		// cap must yield nothing while a disabled cap yields the data tiles.
+		let capped = build_source_with_cap(0, Some(1));
+		let bbox = TileBBox::new_full(0)?;
+		let mut stream = capped.tile_stream(bbox).await?;
+		assert!(
+			stream.next().await.is_none(),
+			"all tiles over a 1-byte cap must be skipped"
+		);
+
+		let uncapped = build_source_with_cap(0, Some(0));
+		let mut stream = uncapped.tile_stream(bbox).await?;
+		assert!(stream.next().await.is_some(), "disabled hard cap must emit the tile");
 		Ok(())
 	}
 

--- a/versatiles_pipeline/src/helpers/tile_size_monitor.rs
+++ b/versatiles_pipeline/src/helpers/tile_size_monitor.rs
@@ -10,7 +10,8 @@
 //!
 //! [`TileSizeMonitor`] sits between the tile encoder and the consumer:
 //!
-//! - **Hard cap** ([`HARD_CAP_BYTES`], 1 MB) → return an error from `check`,
+//! - **Hard cap** (default [`HARD_CAP_BYTES`], 1 MB; configurable per operation
+//!   via `max_tile_bytes`, `0` disables) → return an error from `check`,
 //!   aborting the conversion with a clear message including `(z, x, y)` and
 //!   a breakdown of what's filling the tile (feature count, geometry vs.
 //!   property bytes).
@@ -98,9 +99,9 @@ impl TileBreakdown {
 /// Tiles below this size never trigger a warning.
 pub const SOFT_CAP_BYTES: usize = 200 * 1024;
 
-/// Tiles above this size cause `check` to return an error. ~1 MB is well
-/// past the practical limit of Mapbox / MapLibre style clients and well into
-/// "this feed is misconfigured" territory.
+/// Default value for the hard cap when the operation doesn't configure one.
+/// ~1 MB is well past the practical limit of Mapbox / MapLibre style clients
+/// and well into "this feed is misconfigured" territory.
 pub const HARD_CAP_BYTES: usize = 1024 * 1024;
 
 /// How many of the largest tiles to remember and report at end-of-run.
@@ -117,6 +118,9 @@ pub struct TileSizeMonitor {
 struct MonitorInner {
 	/// Identifier prefix for log lines, e.g. `"from_geo"`.
 	label: &'static str,
+	/// Encoded-blob size above which `check` returns an error. `None` disables
+	/// the hard cap entirely (only the soft-cap warning remains).
+	hard_cap_bytes: Option<usize>,
 	tile_count: AtomicU64,
 	oversized_count: AtomicU64,
 	total_bytes: AtomicU64,
@@ -129,10 +133,11 @@ struct MonitorInner {
 
 impl TileSizeMonitor {
 	#[must_use]
-	pub fn new(label: &'static str) -> Self {
+	pub fn new(label: &'static str, hard_cap_bytes: Option<usize>) -> Self {
 		Self {
 			inner: Arc::new(MonitorInner {
 				label,
+				hard_cap_bytes,
 				tile_count: AtomicU64::new(0),
 				oversized_count: AtomicU64::new(0),
 				total_bytes: AtomicU64::new(0),
@@ -144,7 +149,8 @@ impl TileSizeMonitor {
 	}
 
 	/// Check the encoded blob's size against the soft and hard caps and
-	/// update accounting. Errors when above [`HARD_CAP_BYTES`].
+	/// update accounting. Errors when above the configured hard cap
+	/// ([`HARD_CAP_BYTES`] by default; `None` disables the hard cap).
 	///
 	/// `breakdown` is included in every warning / error message so the user
 	/// can see whether geometry detail or property bloat is the dominant
@@ -153,24 +159,27 @@ impl TileSizeMonitor {
 	pub fn check(&self, coord: TileCoord, blob: &Blob, breakdown: TileBreakdown) -> Result<()> {
 		#[allow(clippy::cast_possible_truncation)]
 		let size = blob.len() as usize;
-		if size > HARD_CAP_BYTES {
+		let inner = &self.inner;
+		if let Some(hard_cap) = inner.hard_cap_bytes
+			&& size > hard_cap
+		{
 			bail!(
 				"{}: tile {}/{}/{} is {} KB, exceeding the {} KB hard cap. \
 				Breakdown: {}. \
 				Likely causes: missing property pruning on a feature-heavy input, \
 				`point_reduction='none'` on a dense point feed, or `max_zoom` set too low \
-				so all features pile into a few tiles.",
-				self.inner.label,
+				so all features pile into a few tiles. Raise the `max_tile_bytes` argument \
+				to accept larger tiles (0 disables the cap).",
+				inner.label,
 				coord.level,
 				coord.x,
 				coord.y,
 				size / 1024,
-				HARD_CAP_BYTES / 1024,
+				hard_cap / 1024,
 				breakdown.fmt_inline(),
 			);
 		}
 
-		let inner = &self.inner;
 		inner.tile_count.fetch_add(1, Ordering::Relaxed);
 		inner.total_bytes.fetch_add(size as u64, Ordering::Relaxed);
 		inner.max_bytes.fetch_max(size, Ordering::Relaxed);
@@ -259,14 +268,14 @@ mod tests {
 
 	#[test]
 	fn under_soft_cap_passes_silently() {
-		let monitor = TileSizeMonitor::new("test");
+		let monitor = TileSizeMonitor::new("test", Some(HARD_CAP_BYTES));
 		let blob = Blob::from(vec![0u8; 1024]);
 		monitor.check(TileCoord::new(0, 0, 0).unwrap(), &blob, TINY).unwrap();
 	}
 
 	#[test]
 	fn over_soft_cap_passes_but_records() {
-		let monitor = TileSizeMonitor::new("test");
+		let monitor = TileSizeMonitor::new("test", Some(HARD_CAP_BYTES));
 		let blob = Blob::from(vec![0u8; SOFT_CAP_BYTES + 1024]);
 		monitor.check(TileCoord::new(5, 1, 2).unwrap(), &blob, TINY).unwrap();
 		// One tile, one oversized.
@@ -276,7 +285,7 @@ mod tests {
 
 	#[test]
 	fn over_hard_cap_errors() {
-		let monitor = TileSizeMonitor::new("test");
+		let monitor = TileSizeMonitor::new("test", Some(HARD_CAP_BYTES));
 		let blob = Blob::from(vec![0u8; HARD_CAP_BYTES + 1]);
 		let err = monitor
 			.check(TileCoord::new(7, 3, 4).unwrap(), &blob, TINY)
@@ -287,11 +296,32 @@ mod tests {
 	}
 
 	#[test]
+	fn disabled_hard_cap_passes_oversized_tile() {
+		// `max_tile_bytes=0` → hard cap disabled: an over-1-MiB tile must pass
+		// the hard-cap check (only soft-cap accounting applies).
+		let monitor = TileSizeMonitor::new("test", None);
+		let blob = Blob::from(vec![0u8; HARD_CAP_BYTES + 1024]);
+		monitor.check(TileCoord::new(7, 3, 4).unwrap(), &blob, TINY).unwrap();
+	}
+
+	#[test]
+	fn custom_hard_cap_errors_at_custom_threshold() {
+		// A per-operation cap of 512 KB: 600 KB errors, 400 KB passes.
+		let monitor = TileSizeMonitor::new("test", Some(512 * 1024));
+		let over = Blob::from(vec![0u8; 600 * 1024]);
+		monitor
+			.check(TileCoord::new(3, 1, 1).unwrap(), &over, TINY)
+			.unwrap_err();
+		let under = Blob::from(vec![0u8; 400 * 1024]);
+		monitor.check(TileCoord::new(3, 1, 1).unwrap(), &under, TINY).unwrap();
+	}
+
+	#[test]
 	fn over_cap_message_includes_breakdown() {
 		// The whole point of carrying TileBreakdown into `check`: the user
 		// debugging an oversized tile sees feature count + geometry/property
 		// bytes in the error message itself.
-		let monitor = TileSizeMonitor::new("test");
+		let monitor = TileSizeMonitor::new("test", Some(HARD_CAP_BYTES));
 		let blob = Blob::from(vec![0u8; HARD_CAP_BYTES + 1]);
 		let breakdown = TileBreakdown {
 			feature_count: 1234,
@@ -309,7 +339,7 @@ mod tests {
 
 	#[test]
 	fn top_n_keeps_largest() {
-		let monitor = TileSizeMonitor::new("test");
+		let monitor = TileSizeMonitor::new("test", Some(HARD_CAP_BYTES));
 		// Five tiles, ascending sizes — only the 5 largest stay (which is all).
 		// Add a 6th and verify the smallest is dropped.
 		let sizes_kb = [210, 220, 230, 240, 250, 260];

--- a/versatiles_pipeline/src/operations/read/from_csv.rs
+++ b/versatiles_pipeline/src/operations/read/from_csv.rs
@@ -77,6 +77,13 @@ struct Args {
 	/// Tile-compression applied before the tiles leave this operation:
 	/// `gzip` (default), `brotli`, `zstd`, or `none`.
 	compression: Option<TileCompression>,
+	/// Maximum encoded tile size in bytes before a tile is considered broken
+	/// and dropped (streaming path) / errors out (single-tile path). Defaults to
+	/// 1048576 (1 MiB). `0` disables the hard cap entirely — tiles are emitted
+	/// at any size (only the 200 KB soft-cap warning remains). Raise this when
+	/// a legitimate low-zoom tile exceeds the default (e.g. `max_tile_bytes=2097152`
+	/// for 2 MiB).
+	max_tile_bytes: Option<u32>,
 }
 
 /// Marker type for the read-factory macro. The actual runtime `TileSource`
@@ -180,6 +187,7 @@ impl ReadTileSource for Operation {
 			"from_csv",
 			"csv features",
 			"csv",
+			args.max_tile_bytes,
 		)?) as Box<dyn TileSource>)
 	}
 }
@@ -222,6 +230,35 @@ mod tests {
 		let vt = versatiles_geometry::vector_tile::VectorTile::from_blob(&blob)?;
 		assert_eq!(vt.layers[0].name, "quakes");
 		assert_eq!(vt.layers[0].features.len(), 3);
+		Ok(())
+	}
+
+	#[tokio::test]
+	async fn max_tile_bytes_propagates_to_single_tile_path() -> Result<()> {
+		const COMMON: &str = "lon_column=\"longitude\" lat_column=\"latitude\" layer_name=\"quakes\" max_zoom=8";
+
+		// A 1-byte cap makes the world tile over-cap: the single-tile API must
+		// surface the error instead of silently returning no tile.
+		let factory = PipelineFactory::new_dummy();
+		let op = factory
+			.operation_from_vpl(&format!(
+				"from_csv filename=\"../testdata/quakes.csv\" max_tile_bytes=1 {COMMON}"
+			))
+			.await?;
+		let err = op.tile(&TileCoord::new(0, 0, 0)?).await.unwrap_err();
+		assert!(format!("{err:#}").contains("hard cap"), "{err:#}");
+
+		// `max_tile_bytes=0` disables the hard cap: the same tile is emitted.
+		let factory = PipelineFactory::new_dummy();
+		let op = factory
+			.operation_from_vpl(&format!(
+				"from_csv filename=\"../testdata/quakes.csv\" max_tile_bytes=0 {COMMON}"
+			))
+			.await?;
+		assert!(
+			op.tile(&TileCoord::new(0, 0, 0)?).await?.is_some(),
+			"disabled hard cap must emit the world tile"
+		);
 		Ok(())
 	}
 

--- a/versatiles_pipeline/src/operations/read/from_geo.rs
+++ b/versatiles_pipeline/src/operations/read/from_geo.rs
@@ -84,6 +84,13 @@ struct Args {
 	/// Tile-compression applied before the tiles leave this operation:
 	/// `gzip` (default), `brotli`, `zstd`, or `none`.
 	compression: Option<TileCompression>,
+	/// Maximum encoded tile size in bytes before a tile is considered broken
+	/// and dropped (streaming path) / errors out (single-tile path). Defaults to
+	/// 1048576 (1 MiB). `0` disables the hard cap entirely — tiles are emitted
+	/// at any size (only the 200 KB soft-cap warning remains). Raise this when
+	/// a legitimate low-zoom tile exceeds the default (e.g. `max_tile_bytes=2097152`
+	/// for 2 MiB).
+	max_tile_bytes: Option<u32>,
 	/// If `true`, drop the GeoJSON / Shapefile `id` field from every feature
 	/// before encoding. Useful for sources where the id is a string (e.g. USGS
 	/// earthquakes — those would be silently dropped at MVT encode anyway, since
@@ -172,6 +179,7 @@ impl ReadTileSource for Operation {
 			"from_geo",
 			"geo features",
 			"geo",
+			args.max_tile_bytes,
 		)?) as Box<dyn TileSource>)
 	}
 }
@@ -298,6 +306,36 @@ mod tests {
 		let vt = versatiles_geometry::vector_tile::VectorTile::from_blob(&blob)?;
 		assert_eq!(vt.layers[0].name, "places");
 		assert_eq!(vt.layers[0].features.len(), 5);
+		Ok(())
+	}
+
+	#[tokio::test]
+	async fn max_tile_bytes_propagates_to_single_tile_path() -> Result<()> {
+		const COMMON: &str = "layer_name=\"places\" max_zoom=8 polygon_simplify=0 line_simplify=0 \
+			 polygon_min_area=0 line_min_length=0";
+
+		// A 1-byte cap makes the world tile over-cap: the single-tile API must
+		// surface the error instead of silently returning no tile.
+		let factory = PipelineFactory::new_dummy();
+		let op = factory
+			.operation_from_vpl(&format!(
+				"from_geo filename=\"../testdata/places.geojson\" max_tile_bytes=1 {COMMON}"
+			))
+			.await?;
+		let err = op.tile(&TileCoord::new(0, 0, 0)?).await.unwrap_err();
+		assert!(format!("{err:#}").contains("hard cap"), "{err:#}");
+
+		// `max_tile_bytes=0` disables the hard cap: the same tile is emitted.
+		let factory = PipelineFactory::new_dummy();
+		let op = factory
+			.operation_from_vpl(&format!(
+				"from_geo filename=\"../testdata/places.geojson\" max_tile_bytes=0 {COMMON}"
+			))
+			.await?;
+		assert!(
+			op.tile(&TileCoord::new(0, 0, 0)?).await?.is_some(),
+			"disabled hard cap must emit the world tile"
+		);
 		Ok(())
 	}
 


### PR DESCRIPTION
## Problem

`from_geo` and `from_csv` enforce a hard-coded 1 MiB cap (`HARD_CAP_BYTES`) on encoded tile size. When a rendered tile exceeds this cap, the streaming path silently drops the tile (returns `None`), leaving holes in PMTiles/MBTiles output while the conversion exits 0. There is no way to configure or disable the cap.

## Solution

Add a new `max_tile_bytes` VPL argument to both operations:

- **not set** → default 1 MiB cap (unchanged behaviour)
- **`max_tile_bytes=0`** → hard cap disabled entirely (only the 200 KB soft-cap warning remains)
- **`max_tile_bytes=N`** → cap encoded tiles at `N` bytes

`TileSizeMonitor` now stores the hard cap per-monitor instance rather than referencing a global constant. `FeatureTileSource` bridges the `Option<u32>` VPL argument to the monitor's internal `Option<usize>` via a `resolve_hard_cap` helper.

## Impact

- Single-tile path (`tile()`) errors when the cap is exceeded — unchanged
- Streaming path (`tile_stream()`) skips over-cap tiles and records them through the error monitor — unchanged
- **New capability**: users with legitimate large tiles can raise or disable the cap instead of losing tiles silently

## Demo

Using a GeoJSON file with 179,729 road features (~255 MB, Overture Maps schema) at `max_zoom=8`:

**Before (default 1 MiB cap) — z8 tile silently dropped:**

```bash
versatiles convert "[,vpl](from_geo filename='data.geojson' max_zoom=8)" output-default.pmtiles
```

> Output: `level 8: 1 tile` — tile `8/129/88` (1376 KB) is discarded, exit 0.

<img width="971" height="483" alt="2" src="https://github.com/user-attachments/assets/4764dd34-d330-499f-b284-b432506bf2f3" />

**After (cap disabled):**

```bash
versatiles convert "[,vpl](from_geo filename='data.geojson' max_zoom=8 max_tile_bytes=0)" output-uncapped.pmtiles
```

> Output: `level 8: 2 tiles` — all tiles preserved.

<img width="1017" height="470" alt="1" src="https://github.com/user-attachments/assets/95ada163-b95c-4f04-b4dc-3dbdd1db91d4" />

## Files Changed

| File | Change |
|---|---|
| `versatiles_pipeline/src/helpers/tile_size_monitor.rs` | `TileSizeMonitor::new(label, hard_cap_bytes: Option<usize>)`; `check()` reads per-monitor cap; error message suggests `max_tile_bytes` argument |
| `versatiles_pipeline/src/helpers/feature_tile_source.rs` | `FeatureTileSource::new` gains `max_tile_bytes: Option<u32>` param; `resolve_hard_cap` helper maps `None`→default, `Some(0)`→disabled, `Some(n)`→n bytes |
| `versatiles_pipeline/src/operations/read/from_geo.rs` | New `max_tile_bytes: Option<u32>` VPL arg, passed through to `FeatureTileSource` |
| `versatiles_pipeline/src/operations/read/from_csv.rs` | New `max_tile_bytes: Option<u32>` VPL arg, passed through to `FeatureTileSource` |
| `versatiles_pipeline/README.md` | Auto-generated doc updated for both operations |

## Testing

- 10 new tests: hard-cap disabled / custom-threshold / message-with-breakdown in the monitor; error-on-single-tile, pass-when-disabled, stream-skip-vs-emit in the source; VPL propagation in both ops
- `cargo test -p versatiles_pipeline` — 582 passed
- `cargo clippy --workspace -- -D warnings` — clean
- `cargo fmt -- --check` — clean
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps"` — clean