### PR TITLE
fix: slashes in source name not working

### DIFF
--- a/versatiles/src/server/routes.rs
+++ b/versatiles/src/server/routes.rs
@@ -53,8 +53,14 @@ pub async fn serve_dynamic_tile(
 	// Lookup source (lock-free!)
 	let tile_source = if let Some(entry) = state.tile_sources.get(source_id) {
 		Arc::clone(entry.value())
+	} else if let Some(source) = (2..parts.len()).rev().find_map(|n| {
+		// source_id may contain slashes, check if progressively shorter prefixes match a source
+		let entry = state.tile_sources.get(&parts[1..=n].join("/"))?;
+		Some(Arc::clone(entry.value()))
+	}) {
+		source
 	} else {
-		log::debug!("tile source '{source_id}' not found");
+		log::debug!("no tile source matches path: {path}");
 		return error_404();
 	};
 


### PR DESCRIPTION
We used slashes in our source names, which used to work prior to version 3. This would re-add that support through an additional check if the normal source check fails.

## Current Problem
In versions 3/4, sources containing slashes do not error on startup and are listed in the tiles index: [https://www.watson.ch/ddj/versatiles/tiles/index.json](https://www.watson.ch/ddj/versatiles/tiles/index.json)

But when trying to access the tiles, a not found error is shown:  [https://www.watson.ch/ddj/versatiles/tiles/2025/de/wahlkreise/meta.json](https://www.watson.ch/ddj/versatiles/tiles/2025/de/wahlkreise/meta.json)

## Fix
Add an additional check that is only run if a simple source match does not return anything. The additional check concatenates the split path and looks if it returns a source.

Currently there are no tests to check this new case, but if you're happy to accept the change, I can try to add those.