### PR TITLE
fix: vendor OpenSSL on darwin so release artifacts load without Homebrew

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -297,7 +297,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Use native runners to avoid cross-compilation; pkg-config finds OpenSSL without extra setup.
+          # Use native runners to avoid cross-compilation. OpenSSL is vendored on
+          # darwin (see versatiles_core/Cargo.toml), so no brew/pkg-config setup
+          # is needed and the artifacts carry no external dylib references.
           - arch: x86_64
             runner: macos-26-intel
           - arch: aarch64

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3426,6 +3426,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "openssl-src"
+version = "300.6.1+3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46eb8fb9fb3b61ce1c0f8a026c4c1a0714d3a9e138e7fbde78753ce2babc3846"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3433,6 +3442,7 @@ checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/versatiles_core/Cargo.toml
+++ b/versatiles_core/Cargo.toml
@@ -43,6 +43,14 @@ zstd = { version = "0.13.3", default-features = false }
 
 versatiles_derive.workspace = true
 
+# OpenSSL must be vendored on darwin: without it, openssl-sys links against
+# Homebrew's OpenSSL through absolute install names (/opt/homebrew/opt/…),
+# so the shipped release artifacts fail to load on any machine that does not
+# have openssl@3 installed at exactly that path. Linux keeps using the
+# system OpenSSL.
+[target.'cfg(target_os = "macos")'.dependencies]
+ssh2 = { version = "0.9", optional = true, features = ["vendored-openssl"] }
+
 [dev-dependencies]
 approx.workspace = true
 assert_fs.workspace = true


### PR DESCRIPTION
## Problem

Since v4.9.0 (when SFTP support was introduced), the macOS release artifacts fail to load on machines that do not have Homebrew's `openssl@3` installed at exactly `/opt/homebrew/opt/openssl@3/`:

- The NAPI binding (`versatiles.darwin-arm64.node` / `versatiles.darwin-x64.node`) is rejected by `dlopen`:

  ```text
  dlopen(versatiles.darwin-arm64.node): Library not loaded:
  /opt/homebrew/opt/openssl@3/lib/libssl.3.dylib
  ```

  In Node the wrapper surfaces this as a misleading `Cannot find native binding`, which makes the real cause hard to diagnose.
- The CLI binary has the same dynamic dependency.

`otool -l` on the published artifacts confirms the dependency: `libssl.3.dylib` and `libcrypto.3.dylib` are referenced by absolute install name, baked in at build time from the GitHub Actions macOS runner's Homebrew installation. Versions 4.9.0 through 4.12.3 are affected; 4.8.0 and earlier are not (verified against published artifacts).

## Root cause

`ssh2` (enabling `sftp://` sources) pulls in `libssh2-sys` → `openssl-sys`. On the macOS runners, `openssl-sys` finds Homebrew's OpenSSL through `pkg-config` and links it dynamically, leaking the runner's absolute paths into the release artifacts.

## Fix

Enable `ssh2`'s `vendored-openssl` feature on darwin targets only, via a target-specific dependency in `versatiles_core` (the only crate that declares `ssh2` directly; both the CLI and the NAPI binding enable it through the `ssh2` feature chain):

```toml
[target.'cfg(target_os = "macos")'.dependencies]
ssh2 = { version = "0.9", optional = true, features = ["vendored-openssl"] }
```

macOS artifacts statically link a vendored OpenSSL (via `openssl-src`) and carry no external dylib references. Linux builds are untouched — `openssl-sys` resolves without the vendored feature on `x86_64-unknown-linux-gnu`, and the musl/static builds keep using their existing provisioning.

## Verification

- Feature resolution (`cargo tree -e features -i openssl-sys --target …`):
  - `aarch64-apple-darwin`: `openssl-sys feature "vendored"` active, through `ssh2 feature "vendored-openssl"` → `libssh2-sys feature "vendored-openssl"`.
  - `x86_64-unknown-linux-gnu`: unchanged (`default` only).
- Built `versatiles_node` locally on darwin-arm64; `otool -L` on the resulting binary shows no reference to Homebrew OpenSSL. (The vendored static lib produces no `libssl`/`libcrypto` entries at all.)
- `cargo-deny` licenses unaffected: `openssl-src` is `Apache-2.0 OR MIT`.

## Trade-off

macOS release builds take a few minutes longer because OpenSSL is compiled from source; Linux build times are unchanged.
